### PR TITLE
Updates to Dockerfile and Dockerfile.rhel7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # playbook2image
 FROM openshift/base-centos7
 
-MAINTAINER Aaron Weitekamp <aweiteka@redhat.com>
+MAINTAINER OpenShift Team <dev@lists.openshift.redhat.com>
 
 # TODO: Rename the builder environment variable to inform users about application you provide them
 # ENV BUILDER_VERSION 1.0
@@ -25,7 +25,6 @@ RUN yum install -y  --setopt=tsflags=nodocs ansible python-pip python-devel && y
 # TODO (optional): Copy the builder files into /opt/app-root
 #COPY ./<builder_folder>/ /opt/app-root/
 
-# TODO: Copy the S2I scripts to /usr/libexec/s2i, since openshift/base-centos7 image sets io.openshift.s2i.scripts-url label that way, or update that label
 COPY ./.s2i/bin/ /usr/libexec/s2i
 COPY user_setup /tmp
 ADD README.md /help.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,7 @@ LABEL io.k8s.description="Ansible playbook to image builder" \
 # ansible and pip are in EPEL
 RUN yum install -y epel-release && yum clean all -y
 
-# workaround for https://github.com/openshift/openshift-ansible/issues/3111
-# install ansible via pip to lock version
-#RUN yum install -y  --setopt=tsflags=nodocs ansible python-pip python-devel && yum clean all -y
-RUN yum install -y  --setopt=tsflags=nodocs python-pip python-devel && yum clean all -y
-RUN pip install -Iv ansible==2.2.0.0
+RUN yum install -y  --setopt=tsflags=nodocs ansible python-pip python-devel && yum clean all -y
 
 # TODO (optional): Copy the builder files into /opt/app-root
 #COPY ./<builder_folder>/ /opt/app-root/

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,7 +1,7 @@
 # playbook2image
 FROM rhscl/python-27-rhel7:2.7
 
-MAINTAINER Aaron Weitekamp <aweiteka@redhat.com>
+MAINTAINER OpenShift Team <dev@lists.openshift.redhat.com>
 
 # TODO: Rename the builder environment variable to inform users about application you provide them
 # ENV BUILDER_VERSION 1.0
@@ -30,7 +30,7 @@ USER root
 # To use a subscription inside container yum command has to be run first (before
 # yum-config-manager) https://access.redhat.com/solutions/1443553
 RUN yum repolist > /dev/null && \
-    yum-config-manager --enable rhel-7-server-ose-3.4-rpms && \
+    yum-config-manager --enable rhel-7-server-ose-3.6-rpms && \
     yum install -y --setopt=tsflags=nodocs ansible && \
     yum clean all -y
 


### PR DESCRIPTION
Some updates to the Dockerfiles to build playbook2image:

- As this moved from Aaron to OpenShift's space, update `MAINTAINER` accordingly
- Update repo to match current downstream builds
- I believe the temporary workaround to pin Ansible version is not needed anymore, so removing it