### PR TITLE
Bring the two description LABELs in sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER OpenShift Team <dev@lists.openshift.redhat.com>
 # TODO: Rename the builder environment variable to inform users about application you provide them
 # ENV BUILDER_VERSION 1.0
 
-LABEL io.k8s.description="Ansible playbook to image builder" \
+LABEL io.k8s.description="Base image to to ship Ansible playbooks as self-executing container image." \
       io.k8s.display-name="playbook2image" \
       io.openshift.tags="builder,ansible,playbook" \
       url="https://github.com/openshift/playbook2image/blob/master/README.md" \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -6,7 +6,7 @@ MAINTAINER OpenShift Team <dev@lists.openshift.redhat.com>
 # TODO: Rename the builder environment variable to inform users about application you provide them
 # ENV BUILDER_VERSION 1.0
 
-LABEL io.k8s.description="Ansible playbook to image builder" \
+LABEL io.k8s.description="Base image to to ship Ansible playbooks as self-executing container image." \
       io.k8s.display-name="playbook2image" \
       io.openshift.tags="builder,ansible,playbook" \
       io.openshift.expose-services="" \


### PR DESCRIPTION
Make the "description" and "io.k8s.description" LABELs match in the Dockerfiles for consistency. 

Also, some build systems like OSBS have a check in place to enforce this and won't build an image with a mismatch.

@aweiteka PTAL thanks
